### PR TITLE
OP-656: Add required project_number variable to resolve for_each error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,37 @@
-# terraform bucket backend module
+# terraform-module-gcp-github-integration
 ===========
 
-A terraform module to provide github action and build connections
+A terraform module to provide GitHub Actions and Cloud Build connections with GCP using Workload Identity Federation.
 
 Module Input Variables
 ----------------------
 
-- `project` - GCP project id
-- `environment` - variable environment
-- `githhub_org` - Github organization
+- `project_id` - GCP project id (required)
+- `project_number` - GCP project number (required)
+- `region` - GCP region (default: us-west1)
+- `github_org` - Github organization (required)
+- `github_token` - Github token (required)
+- `github_app_cloudbuild_installation_id` - Github App Cloud Build Installation Id (required)
+- `terraform_repo_name` - Terraform repository name (default: terraform-gcp)
+- `name` - Pool provider name (optional)
 
 Usage
 -----
 
 ```hcl
 module "github_integration" {
-  source      = "../../../modules/github_integration"
-  project_id  = var.project_id
-  environment = var.environment
-  github_org  = var.github_org
+  source         = "github.com/brandlive1941/terraform-module-gcp-github-integration?ref=v1.2.0"
+  project_id     = var.project_id
+  project_number = var.project_number  # Required - get from GCP console or gcloud
+  github_org     = var.github_org
+  github_token   = var.github_token
+  github_app_cloudbuild_installation_id = var.github_app_cloudbuild_installation_id
 }
+```
+
+**Note:** `project_number` is required and must be passed explicitly. You can get it from GCP Console or by running:
+```bash
+gcloud projects describe PROJECT_ID --format="value(projectNumber)"
 ```
 
 Outputs

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,9 @@
 locals {
   name = var.name == "" ? "gh-${var.github_org}" : var.name
 
+  # Use the provided project_number variable
+  project_number = var.project_number
+
   githubSARoles = [
     "roles/resourcemanager.projectIamAdmin", # GitHub Integration identity
     "roles/editor",                          # allow to manage all resources
@@ -12,16 +15,16 @@ locals {
     "roles/secretmanager.secretAccessor",    # allow to access secrets
     "roles/artifactregistry.reader",         # allow to access Artifact Registry
   ]
-  seretAdmins = [
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"
+  secretAdmins = [
+    "serviceAccount:service-${local.project_number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"
   ]
   secretAccessors = [
-    "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com",
-    "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com",
+    "serviceAccount:${local.project_number}-compute@developer.gserviceaccount.com",
+    "serviceAccount:${local.project_number}@cloudbuild.gserviceaccount.com",
   ]
   githubTokenAccessors = [
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com",
-    "serviceAccount:service-${data.google_project.project.number}@serverless-robot-prod.iam.gserviceaccount.com",
+    "serviceAccount:service-${local.project_number}@gcp-sa-cloudbuild.iam.gserviceaccount.com",
+    "serviceAccount:service-${local.project_number}@serverless-robot-prod.iam.gserviceaccount.com",
   ]
   cloudBuildRoles = [
     "roles/cloudbuild.builds.builder",
@@ -29,8 +32,6 @@ locals {
     "roles/container.developer"
   ]
 }
-
-data "google_project" "project" {}
 
 module "github_token" {
   source     = "github.com/brandlive1941/terraform-module-gcp-secret?ref=v1.0.0"
@@ -51,7 +52,7 @@ module "github_app_cloudbuild_installation_id" {
 }
 
 resource "google_project_iam_member" "cloudbuild_secret_admin" {
-  for_each = toset(local.seretAdmins)
+  for_each = toset(local.secretAdmins)
 
   project = var.project_id
   role    = "roles/secretmanager.admin"
@@ -105,7 +106,7 @@ resource "google_project_iam_member" "cloudbuild_roles" {
   for_each = toset(local.cloudBuildRoles)
   project  = var.project_id
   role     = each.value
-  member   = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member   = "serviceAccount:${local.project_number}@cloudbuild.gserviceaccount.com"
 }
 
 # Allow to access all resources

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "project_id" {
   type        = string
 }
 
+variable "project_number" {
+  description = "GCP Project Number (required for for_each to work at plan time)"
+  type        = string
+}
+
 variable "region" {
   description = "GCP Project Region"
   type        = string


### PR DESCRIPTION
The data.google_project.project.number is unknown until apply, so for_each can't determine the keys.
  - Add project_number as a required variable instead of using data source
  - Remove google_project data source (no longer needed)
  - Update all references from data.google_project.project.number to local.project_number
  - Fix typo: seretAdmins -> secretAdmins
  - Update README with new variable documentation